### PR TITLE
Configure Papaya in dataframe-backed dataclass definition rather than on dataframe instantiation

### DIFF
--- a/src/objects_backing_dataframe.py
+++ b/src/objects_backing_dataframe.py
@@ -112,7 +112,7 @@ def dataframe_backed_object(cls):
             papaya_type = find_papaya_type(
                 field_name,
                 *type(self)._process_type_annotation(field.type),
-                config=self.__df.papaya_types_config,
+                config=self.__df.papaya_config,
             )
             return papaya_type.process_getter_value(value)
         else:
@@ -125,7 +125,7 @@ def dataframe_backed_object(cls):
             papaya_type = find_papaya_type(
                 field_name,
                 *type(self)._process_type_annotation(field.type),
-                config=self.__df.papaya_types_config,
+                config=self.__df.papaya_config,
             )
             self.__df.at[self.__df_key, field_name] = papaya_type.process_setter_value(
                 value

--- a/src/objects_dataframe_base.py
+++ b/src/objects_dataframe_base.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import abc
+import copy
 import dataclasses
 import typing
 import warnings
-from typing import Any, Iterator, Optional, Type
+from typing import Any, Iterator, Optional, Type, _GenericAlias
 
 import pandas as pd
 import pandera.pandas as pa
@@ -13,6 +14,49 @@ from pandera.backends.pandas.container import DataFrameSchemaBackend
 from pandera.engines.pandas_engine import DateTime
 
 from papaya_types import PapayaTypesConfig, find_papaya_type
+
+# The following is copied from module `pandera.typing.common`, with `DataFrameBase`
+# replaced with `ObjectsDataframeBase`. Refer to `ObjectsDataframeBase.__setattr__` for
+# more information.
+
+__orig_generic_alias_call = copy.copy(_GenericAlias.__call__)
+
+
+def __patched_generic_alias_call(self, *args, **kwargs):
+    """
+    Patched implementation of _GenericAlias.__call__ so that validation errors
+    can be raised when instantiating an instance of ObjectsBackingDataframe generics,
+    e.g. ObjectsBackingDataframe[A](data).
+    """
+    if ObjectsDataframeBase not in self.__origin__.__bases__:
+        return __orig_generic_alias_call(self, *args, **kwargs)
+
+    if not self._inst:
+        raise TypeError(
+            f"Type {self._name} cannot be instantiated; "
+            f"use {self.__origin__.__name__}() instead"
+        )
+    result = self.__origin__(*args, **kwargs)
+    try:
+        result.__orig_class__ = self
+    # Limit the patched behavior to subset of exception types
+    except (
+        TypeError,
+        pa.errors.SchemaError,
+        pa.errors.SchemaInitError,
+        pa.errors.SchemaDefinitionError,
+    ):
+        raise
+    # In python 3.11.9, all exceptions when setting attributes when defining
+    # _GenericAlias subclasses are caught and ignored.
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return result
+
+
+_GenericAlias.__call__ = __patched_generic_alias_call
+
+# The preceeding is copied from module `pandera.typing.common`.
 
 
 class ObjectsDataframeBase[T](pd.DataFrame, abc.ABC):
@@ -31,6 +75,10 @@ class ObjectsDataframeBase[T](pd.DataFrame, abc.ABC):
         # use it to validate the DataFrame. This is also what Pandera does.
         if name == "__orig_class__":
             self.validate()
+            # In at least some Python versions, any errors encountered by Python when
+            # setting `__orig_class__` are caught, preventing us from raising from
+            # `.validate` as desired. `__patched_generic_alias_call` overrides this
+            # Python behavior.
 
     def validate(self) -> None:
         schema = self._get_dataframe_schema()

--- a/src/papaya_types.py
+++ b/src/papaya_types.py
@@ -183,7 +183,7 @@ class EnumPapayaType(GeneralPapayaType):
             )
             try:
                 df[self.field_name] = df[self.field_name].astype(self.enum_values_type)
-            except TypeError:
+            except (TypeError, ValueError):
                 pass
 
     @override

--- a/tests/test_objects_backing_dataframe.py
+++ b/tests/test_objects_backing_dataframe.py
@@ -348,9 +348,8 @@ class TestCompatibilityWithEnums:
         (foo_0,) = list(foo_df)
         assert foo_0.enum_field is AnEnum.B
 
-        foo_df = FooDataframe([Foo(enum_field="<invalid-value>")])
         with pytest.raises(pa.errors.SchemaError):
-            foo_df.validate()
+            FooDataframe([Foo(enum_field="<invalid-value>")])
 
     def test_storing_enum_members_as_names(self) -> None:
 
@@ -374,9 +373,8 @@ class TestCompatibilityWithEnums:
         (foo_0,) = list(foo_df)
         assert foo_0.enum_field is AnEnum.B
 
-        foo_df = FooDataframe([Foo(enum_field="<invalid-value>")])
         with pytest.raises(pa.errors.SchemaError):
-            foo_df.validate()
+            FooDataframe([Foo(enum_field="<invalid-value>")])
 
     def test_storing_enum_members_as_integer_values(self) -> None:
 
@@ -400,9 +398,8 @@ class TestCompatibilityWithEnums:
         (foo_0,) = list(foo_df)
         assert foo_0.enum_field is AnEnum.B
 
-        foo_df = FooDataframe([Foo(enum_field="<invalid-value>")])
         with pytest.raises(pa.errors.SchemaError):
-            foo_df.validate()
+            FooDataframe([Foo(enum_field="<invalid-value>")])
 
     def test_storing_enum_members_as_string_values(self) -> None:
         class AnEnum(Enum):
@@ -426,9 +423,8 @@ class TestCompatibilityWithEnums:
         assert type(foo_0.enum_field) is AnEnum
         assert foo_0.enum_field is AnEnum.A
 
-        foo_df = FooDataframe([Foo(enum_field="<invalid-value>")])
         with pytest.raises(pa.errors.SchemaError):
-            foo_df.validate()
+            FooDataframe([Foo(enum_field="<invalid-value>")])
 
     def test_storing_enum_members_as_object_values(self) -> None:
         class AnEnum(Enum):
@@ -471,9 +467,8 @@ class TestCompatibilityWithLiterals:
         assert foo_0.literal_field == 1
 
     def test_validating_literal_values(self) -> None:
-        foo_df = self.FooDataframe([self.Foo(literal_field="<invalid-value>")])
         with pytest.raises(pa.errors.SchemaError):
-            foo_df.validate()
+            self.FooDataframe([self.Foo(literal_field="<invalid-value>")])
 
 
 def _check_foo_types(foo_instance: type) -> None:

--- a/tests/test_objects_backing_dataframe.py
+++ b/tests/test_objects_backing_dataframe.py
@@ -15,6 +15,7 @@ from objects_backing_dataframe import (
     ObjectsBackingDataframe,
     dataframe_backed_object,
 )
+from papaya_types import PapayaTypesConfig
 
 
 def test_dataframe_backed() -> None:
@@ -308,10 +309,10 @@ def test_storing_dates_as_timestamps():
     class Foo:
         date_field: dt.date
 
+        papaya_config = PapayaTypesConfig(store_dates_as_timestamps=True)
+
     FooDataframe = ObjectsBackingDataframe[Foo]  # noqa: N806
-    foo_df = FooDataframe(
-        [Foo(date_field=dt.date(2000, 4, 2))], store_dates_as_timestamps=True
-    )
+    foo_df = FooDataframe([Foo(date_field=dt.date(2000, 4, 2))])
     assert foo_df.dtypes["date_field"] == np.dtype("<M8[ns]")
     assert type(foo_df.loc[0, "date_field"]) is pd.Timestamp
     assert foo_df.loc[0, "date_field"] == pd.Timestamp("2000-04-02")
@@ -325,17 +326,17 @@ def test_storing_dates_as_timestamps():
 
 
 class TestCompatibilityWithEnums:
-    @dataframe_backed_object
-    @dataclasses.dataclass
-    class Foo:
-        enum_field: AnEnum
-
-    foo_instance = Foo(enum_field=AnEnum.A)
-
-    FooDataframe = ObjectsBackingDataframe[Foo]
 
     def test_storing_enum_members_as_members(self) -> None:
-        foo_df = self.FooDataframe([self.foo_instance], store_enum_members_as="members")
+        @dataframe_backed_object
+        @dataclasses.dataclass
+        class Foo:
+            enum_field: AnEnum
+
+            papaya_config = PapayaTypesConfig(store_enum_members_as="members")
+
+        FooDataframe = ObjectsBackingDataframe[Foo]
+        foo_df = FooDataframe([Foo(enum_field=AnEnum.A)])
         assert foo_df.dtypes["enum_field"] == np.dtype("O")
         assert type(foo_df.loc[0, "enum_field"]) is AnEnum
         assert foo_df.loc[0, "enum_field"] is AnEnum.A
@@ -347,12 +348,21 @@ class TestCompatibilityWithEnums:
         (foo_0,) = list(foo_df)
         assert foo_0.enum_field is AnEnum.B
 
-        foo_df = self.FooDataframe([self.Foo(enum_field="<invalid-value>")])
+        foo_df = FooDataframe([Foo(enum_field="<invalid-value>")])
         with pytest.raises(pa.errors.SchemaError):
             foo_df.validate()
 
     def test_storing_enum_members_as_names(self) -> None:
-        foo_df = self.FooDataframe([self.foo_instance], store_enum_members_as="names")
+
+        @dataframe_backed_object
+        @dataclasses.dataclass
+        class Foo:
+            enum_field: AnEnum
+
+            papaya_config = PapayaTypesConfig(store_enum_members_as="names")
+
+        FooDataframe = ObjectsBackingDataframe[Foo]
+        foo_df = FooDataframe([Foo(enum_field=AnEnum.A)])
         assert foo_df.dtypes["enum_field"] == np.dtype("O")
         assert type(foo_df.loc[0, "enum_field"]) is str
         assert foo_df.loc[0, "enum_field"] == "A"
@@ -364,12 +374,21 @@ class TestCompatibilityWithEnums:
         (foo_0,) = list(foo_df)
         assert foo_0.enum_field is AnEnum.B
 
-        foo_df = self.FooDataframe([self.Foo(enum_field="<invalid-value>")])
+        foo_df = FooDataframe([Foo(enum_field="<invalid-value>")])
         with pytest.raises(pa.errors.SchemaError):
             foo_df.validate()
 
     def test_storing_enum_members_as_integer_values(self) -> None:
-        foo_df = self.FooDataframe([self.foo_instance], store_enum_members_as="values")
+
+        @dataframe_backed_object
+        @dataclasses.dataclass
+        class Foo:
+            enum_field: AnEnum
+
+            papaya_config = PapayaTypesConfig(store_enum_members_as="values")
+
+        FooDataframe = ObjectsBackingDataframe[Foo]
+        foo_df = FooDataframe([Foo(enum_field=AnEnum.A)])
         assert foo_df.dtypes["enum_field"] == np.dtype("int64")
         assert type(foo_df.loc[0, "enum_field"]) is np.int64
         assert foo_df.loc[0, "enum_field"] == 1
@@ -381,7 +400,7 @@ class TestCompatibilityWithEnums:
         (foo_0,) = list(foo_df)
         assert foo_0.enum_field is AnEnum.B
 
-        foo_df = self.FooDataframe([self.Foo(enum_field="<invalid-value>")])
+        foo_df = FooDataframe([Foo(enum_field="<invalid-value>")])
         with pytest.raises(pa.errors.SchemaError):
             foo_df.validate()
 
@@ -396,10 +415,10 @@ class TestCompatibilityWithEnums:
         class Foo:
             enum_field: AnEnum
 
+            papaya_config = PapayaTypesConfig(store_enum_members_as="values")
+
         FooDataframe = ObjectsBackingDataframe[Foo]  # noqa: N806
-        foo_df = FooDataframe(
-            [Foo(enum_field=AnEnum.A)], store_enum_members_as="values"
-        )
+        foo_df = FooDataframe([Foo(enum_field=AnEnum.A)])
         assert foo_df.dtypes["enum_field"] == np.dtype("O")
         assert type(foo_df.loc[0, "enum_field"]) is str
         assert foo_df.loc[0, "enum_field"] == "a"
@@ -407,7 +426,7 @@ class TestCompatibilityWithEnums:
         assert type(foo_0.enum_field) is AnEnum
         assert foo_0.enum_field is AnEnum.A
 
-        foo_df = self.FooDataframe([self.Foo(enum_field="<invalid-value>")])
+        foo_df = FooDataframe([Foo(enum_field="<invalid-value>")])
         with pytest.raises(pa.errors.SchemaError):
             foo_df.validate()
 
@@ -422,10 +441,10 @@ class TestCompatibilityWithEnums:
         class Foo:
             enum_field: AnEnum
 
+            papaya_config = PapayaTypesConfig(store_enum_members_as="values")
+
         FooDataframe = ObjectsBackingDataframe[Foo]  # noqa: N806
-        foo_df = FooDataframe(
-            [Foo(enum_field=AnEnum.A)], store_enum_members_as="values"
-        )
+        foo_df = FooDataframe([Foo(enum_field=AnEnum.A)])
         assert foo_df.dtypes["enum_field"] == np.dtype("O")
         assert type(foo_df.loc[0, "enum_field"]) is ZoneInfo
         assert foo_df.loc[0, "enum_field"] == ZoneInfo("America/Toronto")
@@ -600,14 +619,15 @@ class TestStoringNullableIntsAsFloats:
         int_field: int
         nullable_int_field: int | None
 
+        papaya_config = PapayaTypesConfig(store_nullable_ints_as_floats=True)
+
     FooDataframe = ObjectsBackingDataframe[Foo]
 
     def test_with_no_nulls(self) -> None:
         foo_df = self.FooDataframe(
             [
                 self.Foo(int_field=1, nullable_int_field=2),
-            ],
-            store_nullable_ints_as_floats=True,
+            ]
         )
         assert foo_df.dtypes["int_field"] == np.dtype("int64")
         assert foo_df.dtypes["nullable_int_field"] == np.dtype("float64")
@@ -617,8 +637,7 @@ class TestStoringNullableIntsAsFloats:
             [
                 self.Foo(int_field=1, nullable_int_field=None),
                 self.Foo(int_field=1, nullable_int_field=2),
-            ],
-            store_nullable_ints_as_floats=True,
+            ]
         )
         assert foo_df.dtypes["int_field"] == np.dtype("int64")
         assert foo_df.dtypes["nullable_int_field"] == np.dtype("float64")
@@ -627,8 +646,7 @@ class TestStoringNullableIntsAsFloats:
         foo_df = self.FooDataframe(
             [
                 self.Foo(int_field=1, nullable_int_field=None),
-            ],
-            store_nullable_ints_as_floats=True,
+            ]
         )
         assert foo_df.dtypes["int_field"] == np.dtype("int64")
         assert foo_df.dtypes["nullable_int_field"] == np.dtype("float64")
@@ -641,14 +659,15 @@ class TestStoringNullableBoolsAsObjects:
         bool_field: bool
         nullable_bool_field: bool | None
 
+        papaya_config = PapayaTypesConfig(store_nullable_bools_as_objects=True)
+
     FooDataframe = ObjectsBackingDataframe[Foo]
 
     def test_with_no_nulls(self) -> None:
         foo_df = self.FooDataframe(
             [
                 self.Foo(bool_field=True, nullable_bool_field=True),
-            ],
-            store_nullable_bools_as_objects=True,
+            ]
         )
         assert foo_df.dtypes["bool_field"] == np.dtype("bool")
         assert foo_df.dtypes["nullable_bool_field"] == np.dtype("O")
@@ -658,8 +677,7 @@ class TestStoringNullableBoolsAsObjects:
             [
                 self.Foo(bool_field=True, nullable_bool_field=None),
                 self.Foo(bool_field=True, nullable_bool_field=True),
-            ],
-            store_nullable_bools_as_objects=True,
+            ]
         )
         assert foo_df.dtypes["bool_field"] == np.dtype("bool")
         assert foo_df.dtypes["nullable_bool_field"] == np.dtype("O")
@@ -668,8 +686,7 @@ class TestStoringNullableBoolsAsObjects:
         foo_df = self.FooDataframe(
             [
                 self.Foo(bool_field=True, nullable_bool_field=None),
-            ],
-            store_nullable_bools_as_objects=True,
+            ]
         )
         assert foo_df.dtypes["bool_field"] == np.dtype("bool")
         assert foo_df.dtypes["nullable_bool_field"] == np.dtype("O")


### PR DESCRIPTION
Example:

```python
@dataframe_backed_object
@dataclasses.dataclass
class Foo:
    date_field: dt.date

    papaya_config = PapayaTypesConfig(store_dates_as_timestamps=True)

FooDataframe = ObjectsBackingDataframe[Foo]  # noqa: N806
foo_df = FooDataframe([Foo(date_field=dt.date(2000, 4, 2))])
```

Instead of:

```python
@dataframe_backed_object
@dataclasses.dataclass
class Foo:
    date_field: dt.date

FooDataframe = ObjectsBackingDataframe[Foo]  # noqa: N806
foo_df = FooDataframe(
    [Foo(date_field=dt.date(2000, 4, 2))], store_dates_as_timestamps=True
)
```

This avoids wrapping `pandas.DataFrame`'s constructor, having to specify additional kwargs every time you want to instantiate a dataframe, and is more Pydantic-style config.